### PR TITLE
Fix local actions error with password asking

### DIFF
--- a/tasks/authorized_keys.yml
+++ b/tasks/authorized_keys.yml
@@ -1,4 +1,5 @@
 - name: Made a temp global file with all keys
+  become: false
   local_action: 
     module: ansible.builtin.lineinfile 
     line: "{{ lookup('file', item) }}"
@@ -15,6 +16,7 @@
     exclusive: yes
 
 - name: Delete the temp global file with all keys
+  become: false
   local_action: 
     module: file
     state: absent


### PR DESCRIPTION
Solved a problem with local actions in authorized_keys task. 
In some client is possible to need a root password to work fine so we can deactivate privilege escalation in these cases.

[More info](https://docs.ansible.com/ansible/latest/user_guide/become.html#become-directives)